### PR TITLE
Build with raylib-ocaml 2.0

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -28,7 +28,7 @@ Features:
  (depends
   (ocaml (>= 5.2))
   dune-configurator
-  raylib
+  (raylib (>= 2.0.0))
   (alcotest :with-test)
   (odoc :with-doc)
   (bisect_ppx :with-test))

--- a/qcaml.opam
+++ b/qcaml.opam
@@ -32,7 +32,7 @@ depends: [
   "dune" {>= "3.17"}
   "ocaml" {>= "5.2"}
   "dune-configurator"
-  "raylib"
+  "raylib" {>= "2.0.0"}
   "alcotest" {with-test}
   "odoc" {with-doc}
   "bisect_ppx" {with-test}

--- a/src/visualization.ml
+++ b/src/visualization.ml
@@ -161,9 +161,7 @@ let rec loop alpha beta angle_x angle_y font =
 let plot_bloch (qreg: Register.qreg) target () =
   let alpha, beta = Register.get_qubit qreg target in
 
-  (* Reset config flags before setting new ones - fixes issue with multiple windows *)
-  Raylib.set_config_flags [];
-  Raylib.set_config_flags [Raylib.ConfigFlags.Msaa_4x_hint; Raylib.ConfigFlags.Window_resizable];
+  Raylib.set_config_flags Raylib.ConfigFlags.(msaa_4x_hint + window_resizable);
   Raylib.init_window 400 400 "qcaml";
   Raylib.set_window_min_size 400 400;
   Raylib.set_target_fps 60;


### PR DESCRIPTION
I've released a new version of raylib-ocaml which changes slightly the handling of constants, flag-like constants are now values instead of constructors.

It is now no longer possible to set empty config flags, is that a problem? The comment suggests so but an empty list of configflags in the old version evaluated to 0 and the raylib impl of set_config_flags just or-s the new flag with the current one so an empty list should have no effect.